### PR TITLE
feat(frontend): render knowledge graph

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -4,6 +4,7 @@ import { onMounted, ref, nextTick, onUnmounted, onUpdated, watch } from "vue";
 import { downKnowledgeDetails } from "@/api/knowledge-base/index";
 import { MessagePlugin } from "tdesign-vue-next";
 import picturePreview from '@/components/picture-preview.vue';
+import KnowledgeGraph from '@/components/knowledge-graph.vue';
 marked.use({
   mangle: false,
   headerIds: false,
@@ -141,6 +142,7 @@ const handleDetailsScroll = () => {
         : 'background: #3032360f;'
         ">
         <div class="md-content" v-html="processMarkdown(item.content)"></div>
+        <knowledge-graph v-if="item.relation_chunks && item.relation_chunks.length" :chunk="item" />
       </div>
       <template #footer>
         <t-button @click="handleClose">确定</t-button>

--- a/frontend/src/components/knowledge-graph.vue
+++ b/frontend/src/components/knowledge-graph.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+
+const props = defineProps<{ chunk: any }>();
+const graphRef = ref<HTMLDivElement | null>(null);
+
+function loadEcharts(): Promise<any> {
+  return new Promise((resolve, reject) => {
+    if ((window as any).echarts) {
+      resolve((window as any).echarts);
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js';
+    script.onload = () => resolve((window as any).echarts);
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+async function renderGraph() {
+  if (!graphRef.value) return;
+  const echarts = await loadEcharts();
+  const chart = echarts.init(graphRef.value);
+  const nodes: any[] = [
+    {
+      id: props.chunk.id,
+      name: props.chunk.content?.slice(0, 20) || props.chunk.id,
+      symbolSize: 60,
+    },
+  ];
+  const links: any[] = [];
+  (props.chunk.relation_chunks || []).forEach((id: string, index: number) => {
+    nodes.push({ id, name: id, symbolSize: 40 });
+    links.push({ source: props.chunk.id, target: id });
+  });
+  chart.setOption({
+    tooltip: {},
+    series: [
+      {
+        type: 'graph',
+        layout: 'force',
+        roam: true,
+        label: { show: true },
+        data: nodes,
+        links: links,
+        force: { repulsion: 100 },
+      },
+    ],
+  });
+}
+
+onMounted(renderGraph);
+watch(
+  () => props.chunk,
+  () => {
+    renderGraph();
+  },
+  { deep: true }
+);
+</script>
+
+<template>
+  <div ref="graphRef" style="width: 100%; height: 300px;"></div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- import new knowledge graph component and render related chunks beside document text
- add KnowledgeGraph Vue component that loads ECharts dynamically and draws relations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896f5bcf4d8833196511eaad491b8a6