### PR TITLE
feat: gate initialization with env flag

### DIFF
--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -2,5 +2,16 @@
 // 配置这个文件是 解决错误：找不到模块“@/views/login/index.vue”或其相应的类型声明。ts(2307)
 // 这段代码告诉 TypeScript，所有以 .vue 结尾的文件都是 Vue 组件，可以通过 import 语句进行导入。这样做通常可以解决无法识别模块的问题。
 declare module '*.vue' {
-    import { Component } from 'vue'; const component: Component; export default component;
+    import { Component } from 'vue'
+    const component: Component
+    export default component
 }
+
+interface ImportMetaEnv {
+    readonly VITE_SKIP_INIT?: string
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv
+}
+

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,89 +1,96 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { checkInitializationStatus } from '@/api/initialization'
 
+const skipInit = import.meta.env.VITE_SKIP_INIT === 'true'
+
+const routes = [
+  {
+    path: "/",
+    redirect: "/platform",
+  },
+  {
+    path: "/knowledgeBase",
+    name: "home",
+    component: () => import("../views/knowledge/KnowledgeBase.vue"),
+    meta: { requiresInit: true }
+  },
+  {
+    path: "/platform",
+    name: "Platform",
+    redirect: "/platform/knowledgeBase",
+    component: () => import("../views/platform/index.vue"),
+    meta: { requiresInit: true },
+    children: [
+      {
+        path: "knowledgeBase",
+        name: "knowledgeBase",
+        component: () => import("../views/knowledge/KnowledgeBase.vue"),
+        meta: { requiresInit: true }
+      },
+      {
+        path: "creatChat",
+        name: "creatChat",
+        component: () => import("../views/creatChat/creatChat.vue"),
+        meta: { requiresInit: true }
+      },
+      {
+        path: "chat/:chatid",
+        name: "chat",
+        component: () => import("../views/chat/index.vue"),
+        meta: { requiresInit: true }
+      },
+      {
+        path: "settings",
+        name: "settings",
+        component: () => import("../views/settings/Settings.vue"),
+        meta: { requiresInit: true }
+      },
+    ],
+  },
+]
+
+if (!skipInit) {
+  routes.push({
+    path: "/initialization",
+    name: "initialization",
+    component: () => import("../views/initialization/InitializationConfig.vue"),
+    meta: { requiresInit: false } // 初始化页面不需要检查初始化状态
+  })
+}
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [
-    {
-      path: "/",
-      redirect: "/platform",
-    },
-    {
-      path: "/initialization",
-      name: "initialization",
-      component: () => import("../views/initialization/InitializationConfig.vue"),
-      meta: { requiresInit: false } // 初始化页面不需要检查初始化状态
-    },
-    {
-      path: "/knowledgeBase",
-      name: "home",
-      component: () => import("../views/knowledge/KnowledgeBase.vue"),
-      meta: { requiresInit: true }
-    },
-    {
-      path: "/platform",
-      name: "Platform",
-      redirect: "/platform/knowledgeBase",
-      component: () => import("../views/platform/index.vue"),
-      meta: { requiresInit: true },
-      children: [
-        {
-          path: "knowledgeBase",
-          name: "knowledgeBase",
-          component: () => import("../views/knowledge/KnowledgeBase.vue"),
-          meta: { requiresInit: true }
-        },
-        {
-          path: "creatChat",
-          name: "creatChat",
-          component: () => import("../views/creatChat/creatChat.vue"),
-          meta: { requiresInit: true }
-        },
-        {
-          path: "chat/:chatid",
-          name: "chat",
-          component: () => import("../views/chat/index.vue"),
-          meta: { requiresInit: true }
-        },
-        {
-          path: "settings",
-          name: "settings",
-          component: () => import("../views/settings/Settings.vue"),
-          meta: { requiresInit: true }
-        },
-      ],
-    },
-  ],
-});
+  routes,
+})
 
-// 路由守卫：检查系统初始化状态
-router.beforeEach(async (to, from, next) => {
-  // 如果访问的是初始化页面，直接放行
-  if (to.meta.requiresInit === false) {
-    next();
-    return;
-  }
-
-1
-
-  try {
-    // 检查系统是否已初始化
-    const { initialized } = await checkInitializationStatus();
-    
-    if (initialized) {
-      // 系统已初始化，记录到本地存储并正常跳转
-      localStorage.setItem('system_initialized', 'true');
-      next();
-    } else {
-      // 系统未初始化，跳转到初始化页面
-      console.log('系统未初始化，跳转到初始化页面');
-      next('/initialization');
+if (!skipInit) {
+  // 路由守卫：检查系统初始化状态
+  router.beforeEach(async (to, from, next) => {
+    // 如果访问的是初始化页面，直接放行
+    if (to.meta.requiresInit === false) {
+      next()
+      return
     }
-  } catch (error) {
-    console.error('检查初始化状态失败:', error);
-    // 如果检查失败，默认认为需要初始化
-    next('/initialization');
-  }
-});
+
+    try {
+      // 检查系统是否已初始化
+      const { initialized } = await checkInitializationStatus()
+
+      if (initialized) {
+        // 系统已初始化，记录到本地存储并正常跳转
+        localStorage.setItem('system_initialized', 'true')
+        next()
+      } else {
+        // 系统未初始化，跳转到初始化页面
+        console.log('系统未初始化，跳转到初始化页面')
+        next('/initialization')
+      }
+    } catch (error) {
+      console.error('检查初始化状态失败:', error)
+      // 如果检查失败，默认认为需要初始化
+      next('/initialization')
+    }
+  })
+}
 
 export default router


### PR DESCRIPTION
## Summary
- conditionally add initialization route and check based on `VITE_SKIP_INIT`
- declare `VITE_SKIP_INIT` in env typings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899a3e1aef08331adb76d7b094b292d